### PR TITLE
bugfix: we now throw a Lua exception when ngx.location.capture* Lua A…

### DIFF
--- a/src/ngx_http_lua_headers.c
+++ b/src/ngx_http_lua_headers.c
@@ -113,7 +113,7 @@ ngx_http_lua_ngx_req_raw_header(lua_State *L)
 
 #if (NGX_HTTP_V2)
     if (mr->stream) {
-        return luaL_error(L, "http v2 not supported yet");
+        return luaL_error(L, "http2 requests not supported yet");
     }
 #endif
 

--- a/src/ngx_http_lua_subrequest.c
+++ b/src/ngx_http_lua_subrequest.c
@@ -166,6 +166,12 @@ ngx_http_lua_ngx_location_capture_multi(lua_State *L)
         return luaL_error(L, "no request object found");
     }
 
+#if (NGX_HTTP_V2)
+    if (r->main->stream) {
+        return luaL_error(L, "http2 requests not supported yet");
+    }
+#endif
+
     ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
     if (ctx == NULL) {
         return luaL_error(L, "no ctx found");


### PR DESCRIPTION
…PI is used inside an HTTP2 request since it is known to lead to hanging.

I hereby granted the copyright of the changes in this pull request
to the authors of this lua-nginx-module project.
